### PR TITLE
Explicitly enable insecure mode

### DIFF
--- a/examples/init.pp
+++ b/examples/init.pp
@@ -3,9 +3,8 @@
 # Example cockroachdb usage with required parameters
 #
 class { 'cockroachdb':
-  install_path   => '/usr/local/bin',
-  package_ensure => 'v19.1.5.linux-amd64',
-  node1ip        => 'db0',
-  node2ip        => 'db1',
-  node3ip        => 'db2',
+  node1ip     => 'db0',
+  node2ip     => 'db1',
+  node3ip     => 'db2',
+  secure_mode => false,
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,7 @@ class cockroachdb (
 
 ) inherits cockroachdb::params {
   if $cockroachdb::secure_mode != false {
-    fail("The module does not support insecure mode at this time.")
+    fail('The module does not support insecure mode at this time.')
   }
   contain cockroachdb::install
   contain cockroachdb::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,8 @@
 #   Full binary package source.
 # [additional_params]
 #   Additional params and flags to pass to cockroachdb on startup. Must be provided as fully valid cockroachdb flags.
+# [secure_mode]
+#   If cockroachdb secure mode is enabled or not. Currently only supports insecure mode.
 #
 class cockroachdb (
   Optional[Stdlib::Absolutepath] $servicepath      = $cockroachdb::params::servicepath,
@@ -77,6 +79,7 @@ class cockroachdb (
   String $node2ip                                  = $cockroachdb::params::node2ip,
   String $node3ip                                  = $cockroachdb::params::node3ip,
   Optional[String] $additional_params              = $cockroachdb::params::additional_params,
+  Boolean $secure_mode                             = $cockroachdb::params::secure_mode,
 
   #Archive
   Optional[Stdlib::Absolutepath] $install_path     = $cockroachdb::params::install_path,
@@ -87,6 +90,9 @@ class cockroachdb (
   Optional[String] $cockroach_archive_source       = $cockroachdb::params::cockroachdb_package_source,
 
 ) inherits cockroachdb::params {
+  if $cockroachdb::secure_mode != false {
+    fail("The module does not support insecure mode at this time.")
+  }
   contain cockroachdb::install
   contain cockroachdb::config
   contain cockroachdb::service

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class cockroachdb::params {
   $syslogidentifier = 'cockroach'
   $user = 'cockroach'
   $additional_params = ''
+  $secure_mode = undef
 
   # Archive
   $install_path = '/usr/local/bin'

--- a/spec/classes/cockroachdb_spec.rb
+++ b/spec/classes/cockroachdb_spec.rb
@@ -5,11 +5,10 @@ describe 'cockroachdb' do
     context "on #{os}" do
       let(:params) do
         {
-          'install_path' => '/usr/local/bin',
-          'package_ensure' => 'v19.1.5.linux-amd64',
           'node1ip' => 'db0',
           'node2ip' => 'db1',
           'node3ip' => 'db2',
+          'secure_mode' => false,
         }
       end
       let(:facts) { os_facts }


### PR DESCRIPTION
For now, it will fail on purpose when secure_mode is true, as this is not implemented properly as of now.