### PR TITLE
Fix for RPM based distros

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -46,7 +46,6 @@ class cockroachdb::client (
 ) inherits cockroachdb::params {
   package { $dependencies:
     ensure   => installed,
-    provider => apt,
     before   => Archive[$archive_name],
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,6 @@
 class cockroachdb::install {
   package { $cockroachdb::dependencies:
     ensure   => installed,
-    provider => apt,
     before   => Archive[$cockroachdb::archive_name],
   }
 


### PR DESCRIPTION
Explicitly stating apt as a provider prevents this module from working on rpm based systems. apt should already be the default provider for deb based systems, so getting rid of this shouldn't be a problem.